### PR TITLE
Correct linking line for epoxy.

### DIFF
--- a/kwin-effects/CMakeLists.txt
+++ b/kwin-effects/CMakeLists.txt
@@ -92,7 +92,7 @@ target_link_libraries(${HELLOSHADERS}
         Qt5::Gui
         ${KWIN_EFFECTS}
         ${KWIN_GLUTILS}
-    ${EPOXY_LIBRARIES}
+	${EPOXY_LINK_LIBRARIES}
     PRIVATE
         KF5::ConfigCore
         KF5::CoreAddons


### PR DESCRIPTION
This is what should have been here earlier as this variable also includes the -L switch. This makes it possible to build hello on other platforms like FreeBSD.

I see the project is not actively maintained anymore, but I feel like it would be good if the link line was correct. Sorry for the mistake in the previous submission.