### PR TITLE
Fix shaders build on KDE 5.20.9

### DIFF
--- a/kwin-effects/helloshaders.cpp
+++ b/kwin-effects/helloshaders.cpp
@@ -226,7 +226,7 @@ HelloShadersEffect::prePaintWindow(KWin::EffectWindow *w, KWin::WindowPrePaintDa
             || (w == applyEffect)
             )
     {
-        KWin::effects->prePaintWindow(w, data, time);
+        KWin::effects->prePaintWindow(w, data, std::chrono::milliseconds(time));
         return;
     }
     const QRect geo(w->geometry());
@@ -246,7 +246,7 @@ HelloShadersEffect::prePaintWindow(KWin::EffectWindow *w, KWin::WindowPrePaintDa
     outerRect += QRegion(geo.x()+m_size, geo.y(), geo.width()-m_size*2, 1);
     data.paint += outerRect;
     data.clip -=outerRect;
-    KWin::effects->prePaintWindow(w, data, time);
+    KWin::effects->prePaintWindow(w, data, std::chrono::milliseconds(time));
 }
 
 static bool hasShadow(KWin::WindowQuadList &qds)

--- a/kwin-effects/helloshaders.cpp
+++ b/kwin-effects/helloshaders.cpp
@@ -33,6 +33,17 @@ KWIN_EFFECT_FACTORY_SUPPORTED_ENABLED(  HelloShadersFactory,
                                         return HelloShadersEffect::supported();,
                                         return HelloShadersEffect::enabledByDefault();)
 
+struct backCompatChrono {
+    int ms;
+    operator std::chrono::milliseconds() const
+    {
+        return std::chrono::milliseconds(ms);
+    };
+    operator int() const
+    {
+        return ms;
+    };
+};
 
 HelloShadersEffect::HelloShadersEffect() : KWin::Effect(), m_shader(0)
 {
@@ -226,7 +237,7 @@ HelloShadersEffect::prePaintWindow(KWin::EffectWindow *w, KWin::WindowPrePaintDa
             || (w == applyEffect)
             )
     {
-        KWin::effects->prePaintWindow(w, data, std::chrono::milliseconds(time));
+        KWin::effects->prePaintWindow(w, data, backCompatChrono{time});
         return;
     }
     const QRect geo(w->geometry());
@@ -246,7 +257,7 @@ HelloShadersEffect::prePaintWindow(KWin::EffectWindow *w, KWin::WindowPrePaintDa
     outerRect += QRegion(geo.x()+m_size, geo.y(), geo.width()-m_size*2, 1);
     data.paint += outerRect;
     data.clip -=outerRect;
-    KWin::effects->prePaintWindow(w, data, std::chrono::milliseconds(time));
+    KWin::effects->prePaintWindow(w, data, backCompatChrono{time});
 }
 
 static bool hasShadow(KWin::WindowQuadList &qds)


### PR DESCRIPTION
After upgrading to KDE Plasma 5.20.9 I got this error:
```
/home/nico/.cache/yay/hello-kde-git/src/hello/kwin-effects/helloshaders.cpp:229:48: error: cannot convert ‘int’ to ‘std::chrono::milliseconds’ {aka ‘std::chrono::duration<long int, std::ratio<1, 1000> >’}
  229 |         KWin::effects->prePaintWindow(w, data, time);
      |                                                ^~~~
      |                                                |
      |                                                int
In file included from /home/nico/.cache/yay/hello-kde-git/src/hello/kwin-effects/helloshaders.h:23,
                 from /home/nico/.cache/yay/hello-kde-git/src/hello/kwin-effects/helloshaders.cpp:20:
/usr/include/kwineffects.h:838:102: note:   initializing argument 3 of ‘virtual void KWin::EffectsHandler::prePaintWindow(KWin::EffectWindow*, KWin::WindowPrePaintData&, std::chrono::milliseconds)’
  838 |     virtual void prePaintWindow(EffectWindow* w, WindowPrePaintData& data, std::chrono::milliseconds presentTime) = 0;
      |                                                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~
/home/nico/.cache/yay/hello-kde-git/src/hello/kwin-effects/helloshaders.cpp:249:44: error: cannot convert ‘int’ to ‘std::chrono::milliseconds’ {aka ‘std::chrono::duration<long int, std::ratio<1, 1000> >’}
  249 |     KWin::effects->prePaintWindow(w, data, time);
      |                                            ^~~~
      |                                            |
      |                                            int
In file included from /home/nico/.cache/yay/hello-kde-git/src/hello/kwin-effects/helloshaders.h:23,
                 from /home/nico/.cache/yay/hello-kde-git/src/hello/kwin-effects/helloshaders.cpp:20:
/usr/include/kwineffects.h:838:102: note:   initializing argument 3 of ‘virtual void KWin::EffectsHandler::prePaintWindow(KWin::EffectWindow*, KWin::WindowPrePaintData&, std::chrono::milliseconds)’
  838 |     virtual void prePaintWindow(EffectWindow* w, WindowPrePaintData& data, std::chrono::milliseconds presentTime) = 0;
      |                                                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~
In file included from /usr/include/qt/QtCore/qcoreapplication.h:43,
```

I found the commit where the method signature was changed:
https://github.com/KDE/kwin/commit/9f2cb0ae1b6fa6a79158006714907abfac12929a#diff-2f42c80f465471eafc1f0febd9f104a0ef0eef017bb55f1a0c890cebbd4ae78bR62

I fixed this by optionally casting it to a chrono::milliseconds. I added a compatibility type so that it would also compile with the old version